### PR TITLE
Typos, Proper Name Hunting, and Acronyms

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ the install. If you've stumbled here on your own, please request an
 [INVITE](https://www.chef.io/delivery/) or speak with your Chef
 account representative.
 
-These docs will guide you through setting up delivery and configuring
-pipelines once it is setup. You will install the delivery cluster on
+These docs will guide you through setting up Delivery and configuring
+pipelines once it is setup. You will install the Delivery cluster on
 your own infrastructure using chef provisioning and your license
 key. We currently support two install methods. The first is AWS. Using
-this method provisioning will take care of creating all the resources
-and setting them up. The second is SHH. This method is used in all
-other environments and assumes you have created machines and have ssh
+this method of provisioning will take care of creating all the resources
+and setting them up. The second is SSH. This method is used in all
+other environments and assumes you have created machines and have SSH
 access with passwordless SUDO on the boxes.
 
 An important consideration in picking your install method/location is
@@ -38,7 +38,7 @@ internal deployment tool, etc.
     * Note: Sometimes the first converge fails on the build nodes run
       the above step again and it should fix it.
     * Note: For AWS this step creates instances. If there are any
-      failures check your aws console for nodes without names. These
+      failures check your AWS console for nodes without names. These
       can be removed.
 
 4. Sanity Check (from inside delivery-cluster)
@@ -71,31 +71,31 @@ delivery by adding users and organizations.
 
 ### Create an organization
 
-We normally suggest creating a sandbox org where you can have a test
+We normally suggest creating a sandbox organization where you can have a test
 project to play around with.
 
-1. Log into the webui with the admin credentials you got earlier
+1. Log into the web-UI with the admin credentials you got earlier
 
         $ chef exec rake info:delivery_creds
-       
+
 2. Click 'Organizations' in the left column
 3. Click the large orange box on left in header
 4. Enter organization name (sandbox) and save
 
 ### Create users
 
-If you set this up ldap integration you still need to create users in
-delivery, but we will use ldap to get most of the user details and to
+If you set up LDAP integration you still need to create users in
+delivery, but we will use LDAP to get most of the user details and to
 authenticate them.
 
-1. Log into the webui with the admin credentials you got earlier
+1. Log into the web-UI with the admin credentials you got earlier
 
         $ chef exec rake info:delivery_creds
-       
+
 2. Click 'Users' in the left column
 3. Click the large grey box on left in header
 4. Enter user details and save (Give yourself all roles)
-5. Sign-out of the 'admin' acocunt by clicking the user block in the
+5. Sign-out of the 'admin' account by clicking the user block in the
    left column (top dark blue box)
 6. Sign-in with your account
 7. Create any additional users you need
@@ -104,7 +104,7 @@ authenticate them.
 
 1. Install build-essential on linux or developer tools on mac
 2. [Install Git](http://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-3. [Install Chefdk](https://downloads.chef.io/chef-dk/)
+3. [Install ChefDK](https://downloads.chef.io/chef-dk/)
 4. Install 'knife push': ```chef gem install knife-push```
 5. [Install Delivery CLI](install_cli.md)
 

--- a/aws.md
+++ b/aws.md
@@ -1,31 +1,31 @@
 # AWS Install Guide
 
 This guide will help you setup a Delivery cluster in AWS. This will
-invlove creating 6+ new machines depending on what options you choose
+involve creating 6+ new machines depending on what options you choose
 to enable.
 
 ## Create Provisioning Node
 
-You will need a provising node to manage your cluster:
+You will need a provisioning node to manage your cluster:
 [Creating a Provisioning Node](provisioning_node.md)
 
 ## AWS Specific Setup on Provisioning Node
 
 There are few extra steps to do on your provisioning node if you are
-using aws. Run these from your local machine and replace with the
+using AWS. Run these from your local machine and replace with the
 values for your keys.
 
-1. Upload your aws private key:
+1. Upload your AWS private key:
 
         scp -i ~/.ssh/jmorrow-aws.pem ~/.ssh/jmorrow-aws.pem ubuntu@10.194.25.100:/home/ubuntu/.ssh/jmorrow-aws.pem
-        
-2. Upload your aws configuration
+
+2. Upload your AWS configuration
 
         scp -i ~/.ssh/jmorrow-aws.pem -r ~/.aws ubuntu@10.194.25.100:/home/ubuntu/.aws
 
 ## Additional AWS Setup
 
-You will need to have an aws security group with appropriate ports
+You will need to have an AWS security group with appropriate ports
 open. Please refer to the docs in
 [delivery-cluster](https://github.com/opscode-cookbooks/delivery-cluster)
 for the list of ports required.
@@ -40,7 +40,7 @@ provisioning. We use an environment file to do this.
 
         cd ~/delivery-cluster
 
-2. Ensure you have an 'environments' folder
+2. Ensure you have an 'environments' directory
 
         mkdir environments
 

--- a/import_cookbook.md
+++ b/import_cookbook.md
@@ -7,43 +7,43 @@ these steps on your workstation.
 
         mkdir ~/workspace && cd ~/workspace
 
-2. Setup the delivery-cli config
+2. Setup the Delivery-CLI config
 
         delivery setup --server=10.194.9.211 --ent=aws-example --org=sandbox --user=jmorrow
 
 3. Get cookbook source (Pick One)
-  * Cookbook hosted in git and has existing delivery config
-  
+  * Cookbook hosted in git and has existing Delivery config
+
         ```
         git clone https://github.com/opscode-cookbooks/delivery-truck.git
         cd delivery-truck
         ```
     * In this case we are importing from git. Delivery-truck already
-      has a delivery config file so the init step below will not
+      has a Delivery config file so the init step below will not
       create a new review. Instead it will just push the project to
-      your delivery server and create a pipeline.
-    
+      your Delivery server and create a pipeline.
+
   * Cookbook hosted in git
-  
+
           ```
           git clone https://github.com/opscode-cookbooks/postfix.git
           cd postfix
           ```
     * This cookbook will fail linting but shows the import process.
-    
-  * Cookbook in other scm
-  
+
+  * Cookbook in other SCM
+
           ```
           Checkout code from SCM
           cd into directory
-          remove any scm meta data
+          remove any SCM meta data
           git init
           git add .
           git commit -m 'Initial Commit'
           ```
     * Initializes cookbook as a git repo and creates a master branch
       with an initial commit.
-          
+
   * Cookbook Archive
 
         ```
@@ -59,7 +59,7 @@ these steps on your workstation.
     * Initializes cookbook as a git repo and creates a master branch
       with an initial commit.
     * This cookbook will fail linting but shows the import process.
-    
+
 4. Get a Delivery API token
 
         delivery token
@@ -68,11 +68,11 @@ these steps on your workstation.
 
         delivery init
   * Creates a new project in Delivery, pushes the master branch,
-    creates a feature branch, generates a default delivery project
+    creates a feature branch, generates a default Delivery project
     config file, pushes first change for review, and opens browser to
     the change.
   * This sets your new cookbook up to be built with
     [delivery-truck](https://github.com/opscode-cookbooks/delivery-truck). This
-    is Chef's opensource build cookbook for chef cookbooks.
+    is Chef's open-source build cookbook for chef cookbooks.
 
 #### [Continue in README](README.md)

--- a/install_cli.md
+++ b/install_cli.md
@@ -1,12 +1,12 @@
 ## Installing the Delivery CLI
 
-To interact with delivery we suggest you use our cli on your
+To interact with Delivery we suggest you use our CLI on your
 workstation. Currently we support Mac, Ubuntu 14.04, RHEL 6.5, EL 6.5.
 
 ##### Mac
 1. Download the
    [package](https://s3.amazonaws.com/delivery-packages/cli/deliverycli-20150415170013-1.pkg).
-2. Click the pkg and install
+2. Click the package and install
 
 ##### Ubuntu
 

--- a/new_cookbook.md
+++ b/new_cookbook.md
@@ -15,8 +15,8 @@ Delivery. Do these steps on your workstation.
 
         chef generate cookbook new-cookbook
         cd new-cookbook
-  * This use chefdk to generate a new cookbook including a defaualt
-    recipe and default chefspec tests
+  * This use ChefDK to generate a new cookbook including a default
+    recipe and default ChefSpec tests
 
 4. Create initial commit
 
@@ -33,11 +33,11 @@ Delivery. Do these steps on your workstation.
 
         delivery init
   * Creates a new project in Delivery, pushes the master branch,
-    creates a feature branch, generates a default delivery project
+    creates a feature branch, generates a default Delivery project
     config file, pushes first change for review, and opens browser to
     the change.
   * This sets your new cookbook up to be built with
     [delivery-truck](https://github.com/opscode-cookbooks/delivery-truck). This
-    is Chef's opensource build cookbook for chef cookbooks.
+    is Chef's open-source build cookbook for chef cookbooks.
 
 #### [Continue in README](README.md)

--- a/new_cookbook_manual.md
+++ b/new_cookbook_manual.md
@@ -1,19 +1,19 @@
 # Create New Cookbook Manual Delivery Steps
 
 In this example we will create a new cookbook, but do all of the
-delivery steps manually. Run the commands on your workstation.
+Delivery steps manually. Run the commands on your workstation.
 
 1. Create project in Delivery
-  1. Log into the webui with the admin credentials you got earlier
+  1. Log into the web-UI with the admin credentials you got earlier
 
         cat ~/delivery-cluster/.chef/delivery-cluster-data/aws-example.creds
-       
+
   2. Click 'Organizations' in the left column
   3. Click 'sandbox'
   3. Click the large blue box on left in header
   4. Enter project name (new-project2) and save
 
-2. Setup the delivery-cli config
+2. Setup the Delivery-CLI config
 
         delivery setup --server=10.194.9.211 --ent=aws-example --org=sandbox --user=jmorrow
 
@@ -26,13 +26,14 @@ delivery steps manually. Run the commands on your workstation.
 
         chef generate cookbook .
 
-  * This use chefdk to generate a new cookbook including a defaualt
-    recipe and default chefspec tests
+  * This use ChefDK to generate a new cookbook including a default
+    recipe and default ChefSpec tests
 
 4. Create initial commit
 
         git add .
         git commit -m 'Initial Commit'
+
   * Initializes a git repo and creates a master branch with an initial
     commit.
 
@@ -41,12 +42,12 @@ delivery steps manually. Run the commands on your workstation.
         git push delivery master
 
 6. Create pipeline in Delivery
-  1. Log into the webui with the admin credentials you got earlier
+  1. Log into the web-UI with the admin credentials you got earlier
 
         ```
         cat ~/delivery-cluster/.chef/delivery-cluster-data/aws-example.creds
         ```
-        
+
   2. Click 'Organizations' in the left column
   3. Click 'sandbox'
   4. Click 'new-project2'
@@ -56,7 +57,7 @@ delivery steps manually. Run the commands on your workstation.
 
 7. Initialize the cookbook for Delivery
   1. Create feature branch
-  
+
         ```
         git checkout -b add_delivery_config
         ```
@@ -67,7 +68,7 @@ delivery steps manually. Run the commands on your workstation.
         mkdir .delivery
         vi .delivery/config.json
         ```
-        
+
         ```
         {
           "version": "2",
@@ -85,8 +86,8 @@ delivery steps manually. Run the commands on your workstation.
         ```
     * This sets your new cookbook up to be built with
       [delivery-truck](https://github.com/opscode-cookbooks/delivery-truck). This
-      is Chef's opensource build cookbook for chef cookbooks.
-    
+      is Chef's open-source build cookbook for chef cookbooks.
+
 8. Add changes to feature branch
 
         git add .

--- a/provisioning_node.md
+++ b/provisioning_node.md
@@ -17,12 +17,12 @@ t2.micro (1 CPU 2.5GHz, 1 GiB Mem, 8 GiB Disk).
 
 If you choose not to use a provisioning node do this on your
 workstation. These use generic install instructions for the
-prerequisites if you perfer a different install method it should be
+prerequisites if you prefer a different install method it should be
 fine to use your own. You will want open these links in a new tab.
 
 1. Install build-essential on linux or developer tools on mac
 2. [Install Git](http://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
-3. [Install Chefdk](https://downloads.chef.io/chef-dk/)
+3. [Install ChefDK](https://downloads.chef.io/chef-dk/)
 4. Install 'knife push': ```chef gem install knife-push```
 5. Get License Key: ```curl -o delivery.license '{your_license_url}'```
 6. Get Delivery Cluster: ```git clone https://github.com/opscode-cookbooks/delivery-cluster.git```

--- a/ssh.md
+++ b/ssh.md
@@ -1,12 +1,12 @@
 # SSH Install Guide
 
 This guide will help you setup a Delivery cluster using SSH. This will
-invlove creating 6+ new machines depending on what options you choose
+involve creating 6+ new machines depending on what options you choose
 to enable.
 
 ## Create Provisioning Node
 
-You will need a provising node to manage your cluster:
+You will need a provisioning node to manage your cluster:
 [Creating a Provisioning Node](provisioning_node.md)
 
 ## Create Additional Nodes
@@ -15,16 +15,16 @@ You will next create nodes for the delivery infrastructure. For the
 minimal setup you will need 5 additional nodes. In AWS we use
 c3.xlarge machines (8 CPU 2.5GHz, 7.5 GiB Mem, 2 x40 GiB Disk). You
 can probably get away with something a little smaller as long as you
-have multiple cores. For each of these machines ensure you can ssh and
+have multiple cores. For each of these machines ensure you can SSH and
 SUDO without a password from the provisioning node.
 
 ## SSH Specific Setup on Provisioning Node
 
 There are few extra steps to do on your provisioning node if you are
-using ssh. Run these from your local machine and replace with the
+using SSH. Run these from your local machine and replace with the
 values for your keys.
 
-1. Upload your aws private key:
+1. Upload your AWS private key:
 
         scp -i ~/.ssh/jmorrow-aws.pem ~/.ssh/jmorrow-aws.pem ubuntu@10.194.25.100:/home/ubuntu/.ssh/jmorrow-aws.pem
 


### PR DESCRIPTION
Combed through the documentation with an eye for fixing a few misspelled words, capitalization of acronyms, and titleizing the use of the word Delivery when referring to the product.

This is based on @seth branch because hard-wrap seems like it would cause some merge conflicts.
